### PR TITLE
9 create regular expression lexer

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -1,0 +1,55 @@
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::fmt::Formatter;
+
+#[cfg(test)]
+mod tests;
+
+#[derive(Debug, PartialEq)]
+struct LexicalError {
+    remaining_string: String,
+}
+
+impl Display for LexicalError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "A lexical error occurred at {}", self.remaining_string)
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+enum Token {
+    Char(char),
+    Choice,
+    Closure,
+    LeftPrecedence,
+    RightPrecedence,
+    EmptyString,
+}
+
+fn match_token<'a>(
+    token_map: &HashMap<String, Token>,
+    input_string: &'a str,
+) -> Result<(Token, &'a str), LexicalError> {
+    for (string, token) in token_map {
+        if input_string.starts_with(string) {
+            return Ok((*token, &input_string[string.len()..]));
+        }
+    }
+    Err(LexicalError {
+        remaining_string: String::from(input_string),
+    })
+}
+
+fn lex_string(
+    token_map: &HashMap<String, Token>,
+    input_string: &str,
+) -> Result<Vec<Token>, LexicalError> {
+    let mut token_stream: Vec<Token> = Vec::new();
+    let mut remaining_input_string = input_string;
+    while !remaining_input_string.is_empty() {
+        let token: Token;
+        (token, remaining_input_string) = match_token(token_map, remaining_input_string)?;
+        token_stream.push(token);
+    }
+    Ok(token_stream)
+}

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -22,6 +22,7 @@ impl Display for CharacterParsingError {
 
 #[derive(Debug, PartialEq)]
 struct ReservedTokenOverwriteError {
+    overwritten_string: String,
     overwritten_token: Token,
 }
 
@@ -29,8 +30,8 @@ impl Display for ReservedTokenOverwriteError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(
             f,
-            "A user-defined character has overwritten a reserved token {}. Please check the documentation to see which characters are reserved.",
-            self.overwritten_token
+            "A user-defined character {} has overwritten a reserved token {}. Please check the documentation to see which characters are reserved.",
+            self.overwritten_string, self.overwritten_token
         )
     }
 }
@@ -38,17 +39,40 @@ impl Display for ReservedTokenOverwriteError {
 #[derive(Debug, PartialEq)]
 enum LexicalError {
     CharacterParsingError(CharacterParsingError),
+    ReservedTokenOverwriteError(ReservedTokenOverwriteError),
 }
 
+#[derive(Debug)]
 struct TokenMap {
     token_map: HashMap<String, Token>,
 }
 
 impl TokenMap {
-    fn verify_reserved_tokens_exist(&self) {}
+    fn verify_reserved_tokens_exist(
+        token_map: &HashMap<String, Token>,
+    ) -> Result<(), LexicalError> {
+        let reserved_token_map = generate_reserved_token_map();
+        for (reserved_key, reserved_token) in reserved_token_map {
+            match token_map[&reserved_key] {
+                Token::ReservedToken(_) => continue,
+                _ => {
+                    return Err(LexicalError::ReservedTokenOverwriteError(
+                        ReservedTokenOverwriteError {
+                            overwritten_string: reserved_key,
+                            overwritten_token: reserved_token,
+                        },
+                    ))
+                }
+            }
+        }
+        Ok(())
+    }
 
-    fn new(token_map: HashMap<String, Token>) -> Result<TokenMap, CharacterParsingError> {
-        Ok(TokenMap{token_map: token_map})
+    fn new(token_map: HashMap<String, Token>) -> Result<TokenMap, LexicalError> {
+        TokenMap::verify_reserved_tokens_exist(&token_map)?;
+        Ok(TokenMap {
+            token_map: token_map,
+        })
     }
 }
 
@@ -88,11 +112,44 @@ impl Display for Token {
     }
 }
 
+fn generate_reserved_token_map() -> HashMap<String, Token> {
+    HashMap::from([
+        (
+            String::from("|"),
+            Token::ReservedToken(ReservedToken::Choice),
+        ),
+        (
+            String::from("*"),
+            Token::ReservedToken(ReservedToken::Closure),
+        ),
+        (
+            String::from("("),
+            Token::ReservedToken(ReservedToken::LeftPrecedence),
+        ),
+        (
+            String::from(")"),
+            Token::ReservedToken(ReservedToken::RightPrecedence),
+        ),
+        (
+            String::from("\\e"),
+            Token::ReservedToken(ReservedToken::EmptyString),
+        ),
+    ])
+}
+
+fn generate_token_map(alphabet: &str) -> Result<TokenMap, LexicalError> {
+    let mut token_map = generate_reserved_token_map();
+    for c in alphabet.chars() {
+        token_map.insert(String::from(c), Token::Char(c));
+    }
+    TokenMap::new(token_map)
+}
+
 fn match_token<'a>(
-    token_map: &HashMap<String, Token>,
+    token_map: &TokenMap,
     input_string: &'a str,
 ) -> Result<(Token, &'a str), LexicalError> {
-    for (string, token) in token_map {
+    for (string, token) in &token_map.token_map {
         if input_string.starts_with(string) {
             return Ok((*token, &input_string[string.len()..]));
         }
@@ -102,10 +159,7 @@ fn match_token<'a>(
     }))
 }
 
-fn lex_string(
-    token_map: &HashMap<String, Token>,
-    input_string: &str,
-) -> Result<Vec<Token>, LexicalError> {
+fn lex_string(token_map: &TokenMap, input_string: &str) -> Result<Vec<Token>, LexicalError> {
     let mut token_stream: Vec<Token> = Vec::new();
     let mut remaining_input_string = input_string;
     while !remaining_input_string.is_empty() {

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -74,3 +74,12 @@ fn test_invalid_input_utf8() {
     let lexed_string = lex_string(&token_map, test_input);
     assert_eq!(expected_output, lexed_string);
 }
+
+#[test]
+fn test_empty_input() {
+    let token_map = generate_token_map("");
+    let test_input = "";
+    let expected_output = Ok(vec![]);
+    let lexed_string = lex_string(&token_map, test_input);
+    assert_eq!(expected_output, lexed_string);
+}

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -63,3 +63,14 @@ fn test_token_match_utf8() {
     let lexed_string = lex_string(&token_map, test_input);
     assert_eq!(expected_output, lexed_string);
 }
+
+#[test]
+fn test_invalid_input_utf8() {
+    let token_map = generate_token_map("ab⟹🦀");
+    let test_input = "a🦀A🦀";
+    let expected_output = Err(LexicalError {
+        remaining_string: String::from("A🦀"),
+    });
+    let lexed_string = lex_string(&token_map, test_input);
+    assert_eq!(expected_output, lexed_string);
+}

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -1,0 +1,65 @@
+use std::string;
+
+use super::*;
+
+fn generate_token_map(alphabet: &'static str) -> HashMap<String, Token> {
+    let mut token_map = HashMap::from([
+        (String::from("|"), Token::Choice),
+        (String::from("*"), Token::Closure),
+        (String::from("("), Token::LeftPrecedence),
+        (String::from(")"), Token::RightPrecedence),
+        (String::from("\\e"), Token::EmptyString),
+    ]);
+    for c in alphabet.chars() {
+        token_map.insert(String::from(c), Token::Char(c));
+    }
+    token_map
+}
+
+#[test]
+fn test_token_match_ascii() {
+    let token_map = generate_token_map("ab");
+    let test_input = "a(b*)a|\\e";
+    let expected_output = Ok(vec![
+        Token::Char('a'),
+        Token::LeftPrecedence,
+        Token::Char('b'),
+        Token::Closure,
+        Token::RightPrecedence,
+        Token::Char('a'),
+        Token::Choice,
+        Token::EmptyString,
+    ]);
+    let lexed_string = lex_string(&token_map, test_input);
+    assert_eq!(expected_output, lexed_string);
+}
+
+#[test]
+fn test_invalid_input_ascii() {
+    let token_map = generate_token_map("ab");
+    let test_input = "aA";
+    let expected_output = Err(LexicalError {
+        remaining_string: String::from("A"),
+    });
+    let lexed_string = lex_string(&token_map, test_input);
+    assert_eq!(expected_output, lexed_string);
+}
+
+#[test]
+fn test_token_match_utf8() {
+    let token_map = generate_token_map("ab⟹🦀");
+    let test_input = "a|b|(🦀⟹)*";
+    let expected_output = Ok(vec![
+        Token::Char('a'),
+        Token::Choice,
+        Token::Char('b'),
+        Token::Choice,
+        Token::LeftPrecedence,
+        Token::Char('🦀'),
+        Token::Char('⟹'),
+        Token::RightPrecedence,
+        Token::Closure,
+    ]);
+    let lexed_string = lex_string(&token_map, test_input);
+    assert_eq!(expected_output, lexed_string);
+}

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -81,3 +81,15 @@ fn test_overwrite_reserved_token() {
         })
     );
 }
+
+#[test]
+fn test_violate_prefix_property() {
+    let token_map = generate_token_map("\\").unwrap_err();
+    assert_eq!(
+        token_map,
+        LexicalError::PrefixPropertyViolationError(PrefixPropertyViolationError {
+            contained_string: String::from("\\"),
+            containing_string: String::from("\\e"),
+        })
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,3 @@
 #![doc = include_str!("../README.md")]
+
+mod lexer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(missing_docs)]
+
 #![doc = include_str!("../README.md")]
 
 mod lexer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![warn(missing_docs)]
-
 #![doc = include_str!("../README.md")]
 
 mod lexer;


### PR DESCRIPTION
## Overview

<!-- Provide a brief overview of the contents of this PR, including when applicable: 
    - Links to relevant resources e.g. documentation or related issues
    - Commentary on any changes made to the proposals made in any related issues
-->

This PR implements lexing logic for the concrete syntax defined in the docs under #syntax over a user-defined alphabet.

- Related issue #9 
- Related parent issue #6 

## Validation

<!-- Describe how you validated this MR, including when applicable: 
    - Screenshots of the visual changes made
    - An ordered list of steps for local validation
    - An overview of the automated tests added to the codebase
-->

Automated tests covering the following cases have been created and passed:
- ascii input:
    - valid input creates expected stream
    - input containing characters not in the user-defined alphabet throws expected error
- utf8 variable input:
    - valid input creates expected stream
    - input containing characters not in the user-defined alphabet throws expected error
- empty input simply returns empty stream
- an input alphabet containing characters which overwrite reserved characters throws expected error
- an input alphabet containing characters which violate the prefix property throws expected error
