### PR TITLE
23 document private functionality

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustdocflags = "--html-in-header katex-header.html --document-private-items"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [dependencies]
 
 [package.metadata.docs.rs]
-rustdoc-args = [ "--html-in-header", "katex-header.html" ]
+rustdoc-args = [ "--html-in-header", "katex-header.html", "--document-private-items" ]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The syntax is given in a language based on [EBNF](https://en.wikipedia.org/wiki/
 /* Expression types ordered by precidence
 --------------------------------------------------------------------- */
 
-Expression          ::= [Choice]
+Expression          ::= Choice
 
 Choice              ::= [Concatenation] {CHOICE Concatenation}
 

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -67,8 +67,6 @@ impl Display for PrefixPropertyViolationError {
 }
 
 /// Wraps all lexer-based errors.
-/// 
-/// In the future may be exposed.
 #[derive(Debug, PartialEq)]
 enum LexicalError {
     CharacterParsingError(CharacterParsingError),


### PR DESCRIPTION
## Overview

<!-- Provide a brief overview of the contents of this PR, including when applicable: 
    - Links to relevant resources e.g. documentation or related issues
    - Commentary on any changes made to the proposals made in any related issues
-->

Added documentation to the existing modules, which is displayed in the rustdoc generated docs.

## Validation

<!-- Describe how you validated this MR, including when applicable: 
    - Screenshots of the visual changes made
    - An ordered list of steps for local validation
    - An overview of the automated tests added to the codebase
-->

```bash
cargo doc --open
```

Private submodules are visible on the home page:
<img width="1440" alt="Screenshot 2025-02-10 at 19 28 09" src="https://github.com/user-attachments/assets/459e9afd-b479-4636-89cf-bc8dc3eff10e" />

Lexer documentation:
<img width="1440" alt="Screenshot 2025-02-10 at 19 28 19" src="https://github.com/user-attachments/assets/682c9a6d-45f5-47b6-87e1-ac20d4835749" />

Parser documentation:
<img width="1439" alt="Screenshot 2025-02-10 at 19 28 29" src="https://github.com/user-attachments/assets/46ec3f9c-c783-4d52-9e3f-7931457a2a5e" />

