### PR TITLE
29 expose end to end dfa generation

### DIFF
--- a/src/dfa/mod.rs
+++ b/src/dfa/mod.rs
@@ -8,18 +8,18 @@ mod tests;
 
 /// Represents a DFA
 #[derive(Debug, PartialEq)]
-struct Dfa {
+pub struct Dfa {
     /// The number of states in the DFA. The states of the DFA are thus 0..n_states.
-    n_states: usize,
+    pub(crate) n_states: usize,
     /// The starting state of the DFA.
-    start_state: usize,
+    pub(crate) start_state: usize,
     /// A set of accepting states. If, after consuming an input string, the DFA is at an
     /// accepting state, then it accepts the input string, otherwise it rejects it.
-    accepting_states: HashSet<usize>,
+    pub(crate) accepting_states: HashSet<usize>,
     /// The transition function from state X alphabet -> state. If an entry does not
     /// exist for state n, char c then this implies that the DFA rejects any word
     /// which follows that path.
-    transition_function: HashMap<usize, HashMap<char, usize>>,
+    pub(crate) transition_function: HashMap<usize, HashMap<char, usize>>,
 }
 
 /// calculate_matches_next(e)[i] is a set of the leaf nodes which will match the first
@@ -57,7 +57,7 @@ fn calculate_matches_next(
 }
 
 /// Generates a DFA from an input annotated expression with leaf context.
-fn generate_dfa(expression: AnnotatedExpressionContext) -> Dfa {
+pub(crate) fn generate_dfa(expression: AnnotatedExpressionContext) -> Dfa {
     let mut matches_next = vec![HashSet::<usize>::new(); expression.leaves.len()];
     let mut unmarked_states_map = HashMap::new();
     let mut marked_states_map = HashMap::new();

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -13,8 +13,8 @@ mod tests;
 
 /// Runtime error representing that the input string is not parsable to a [`Token`].
 #[derive(Debug, PartialEq)]
-struct CharacterParsingError {
-    unmatchable_char: char,
+pub struct CharacterParsingError {
+    pub(crate) unmatchable_char: char,
 }
 
 impl Display for CharacterParsingError {
@@ -29,7 +29,7 @@ impl Display for CharacterParsingError {
 
 /// Runtime error representing that the input alphabet overwrote some reserved [`Token`].
 #[derive(Debug, PartialEq)]
-struct ReservedTokenOverwriteError {
+pub struct ReservedTokenOverwriteError {
     overwritten_string: String,
     overwritten_token: Token,
 }
@@ -51,7 +51,7 @@ impl Display for ReservedTokenOverwriteError {
 /// development as there are open issues which may result in changes to the input alphabet,
 /// allowing it to contain arbitrary-length strings.
 #[derive(Debug, PartialEq)]
-struct PrefixPropertyViolationError {
+pub struct PrefixPropertyViolationError {
     contained_string: String,
     containing_string: String,
 }
@@ -68,7 +68,7 @@ impl Display for PrefixPropertyViolationError {
 
 /// Wraps all lexer-based errors.
 #[derive(Debug, PartialEq)]
-enum LexicalError {
+pub enum LexicalError {
     CharacterParsing(CharacterParsingError),
     ReservedTokenOverwrite(ReservedTokenOverwriteError),
     PrefixPropertyViolation(PrefixPropertyViolationError),
@@ -78,7 +78,7 @@ enum LexicalError {
 ///
 /// Constructor [`TokenMap::new`] ensures certain properties are met at runtime.
 #[derive(Debug)]
-struct TokenMap {
+pub(crate) struct TokenMap {
     token_map: HashMap<String, Token>,
 }
 
@@ -130,7 +130,7 @@ impl TokenMap {
 
 /// [`Token`]s that don't represent matches to characters in the user-defined alphabet.
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub enum ReservedToken {
+pub(crate) enum ReservedToken {
     Choice,
     Closure,
     LeftPrecedence,
@@ -154,7 +154,7 @@ impl Display for ReservedToken {
 /// char and [`Token`], but in the future this abstraction may help the parser by wrapping
 /// multi-char [`Token`]s.
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub enum Token {
+pub(crate) enum Token {
     Char(char),
     ReservedToken(ReservedToken),
 }
@@ -191,7 +191,7 @@ fn generate_reserved_token_map() -> HashMap<String, Token> {
 }
 
 /// Generates a [`HashMap<String, Token>`] from an input [`str`] alphabet.
-fn generate_token_map(alphabet: &str) -> Result<TokenMap, LexicalError> {
+pub(crate) fn generate_token_map(alphabet: &str) -> Result<TokenMap, LexicalError> {
     let mut token_map = generate_reserved_token_map();
     for c in alphabet.chars() {
         token_map.insert(String::from(c), Token::Char(c));
@@ -215,7 +215,10 @@ fn match_token<'a>(
 }
 
 /// Generates a [`Vec<Token>`] representing the input_string from the token_map.
-fn lex_string(token_map: &TokenMap, input_string: &str) -> Result<Vec<Token>, LexicalError> {
+pub(crate) fn lex_string(
+    token_map: &TokenMap,
+    input_string: &str,
+) -> Result<Vec<Token>, LexicalError> {
     let mut token_stream: Vec<Token> = Vec::new();
     let mut remaining_input_string = input_string;
     while !remaining_input_string.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,45 @@ mod annotator;
 mod dfa;
 mod lexer;
 mod parser;
+
+#[cfg(test)]
+mod tests;
+
+/// Represents an error during the creation of the DFA.
+#[derive(Debug, PartialEq)]
+pub enum DfaGenerationError {
+    /// Represents an error during lexing of the input regular expression and alphabet
+    /// into a token stream.
+    Lexical(lexer::LexicalError),
+    /// Represents an error during parsing of the token stream to an AST.
+    Syntactic(parser::SyntacticError),
+    /// Represents an error during annotation of the AST.
+    Annotation(annotator::AnnotationError),
+}
+
+impl From<lexer::LexicalError> for DfaGenerationError {
+    fn from(value: lexer::LexicalError) -> Self {
+        DfaGenerationError::Lexical(value)
+    }
+}
+
+impl From<parser::SyntacticError> for DfaGenerationError {
+    fn from(value: parser::SyntacticError) -> Self {
+        DfaGenerationError::Syntactic(value)
+    }
+}
+
+impl From<annotator::AnnotationError> for DfaGenerationError {
+    fn from(value: annotator::AnnotationError) -> Self {
+        DfaGenerationError::Annotation(value)
+    }
+}
+
+/// Generates a DFA from an input regular expression string and alphabet.
+pub fn generate_dfa(raw_expression: &str, alphabet: &str) -> Result<dfa::Dfa, DfaGenerationError> {
+    let sanitised_alphabet = lexer::generate_token_map(alphabet)?;
+    let lexed_expression = lexer::lex_string(&sanitised_alphabet, raw_expression)?;
+    let parsed_expression = parser::parse(lexed_expression)?;
+    let annotated_expression = annotator::annotate_ast(parsed_expression)?;
+    Ok(dfa::generate_dfa(annotated_expression))
+}

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -46,6 +46,10 @@ fn test_closure_fails_on_empty_string() {
     let test_input = vec![Token::ReservedToken(ReservedToken::Closure)];
     let expected_output = SyntacticError::UnexpectedToken(UnexpectedTokenError {
         token: Token::ReservedToken(ReservedToken::Closure),
+        expected_tokens: vec![
+            Token::Char('.'),
+            Token::ReservedToken(ReservedToken::LeftPrecedence),
+        ],
     });
     assert_eq!(parse(test_input).unwrap_err(), expected_output);
 }
@@ -123,15 +127,8 @@ fn test_choice_on_concatenation() {
 fn test_choice_on_empty_string() {
     let test_input = vec![
         Token::ReservedToken(ReservedToken::Choice),
-        Token::ReservedToken(ReservedToken::Choice),
         Token::Char('a'),
-        Token::ReservedToken(ReservedToken::Choice),
     ];
-    let expected_output = Expression::Choice(vec![
-        Expression::EmptyString,
-        Expression::EmptyString,
-        Expression::Char('a'),
-        Expression::EmptyString,
-    ]);
+    let expected_output = Expression::Choice(vec![Expression::EmptyString, Expression::Char('a')]);
     assert_eq!(parse(test_input).unwrap(), expected_output);
 }

--- a/src/tests/dfa_generation_tests.rs
+++ b/src/tests/dfa_generation_tests.rs
@@ -199,7 +199,7 @@ fn test_invalid_choice_character_empty_string() {
 
 #[test]
 fn test_choice_empty_string_empty_string() {
-    let input_expression = "()|()";
+    let input_expression = "|()";
     let input_alphabet = "ab";
     let expected_output = dfa::Dfa {
         n_states: 1,

--- a/src/tests/dfa_generation_tests.rs
+++ b/src/tests/dfa_generation_tests.rs
@@ -75,8 +75,54 @@ fn test_invalid_closure_empty_string() {
 }
 
 #[test]
+fn test_closure_closure_empty_string() {
+    let input_expression = "(()*)*";
+    let input_alphabet = "";
+    let expected_output = dfa::Dfa {
+        n_states: 1,
+        start_state: 0,
+        accepting_states: HashSet::from([0]),
+        transition_function: HashMap::new(),
+    };
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_invalid_closure_closure_empty_string() {
+    let input_expression = "()**";
+    let input_alphabet = "";
+    let expected_output = DfaGenerationError::Syntactic(parser::SyntacticError::UnexpectedToken(
+        parser::UnexpectedTokenError {
+            token: lexer::Token::ReservedToken(lexer::ReservedToken::Closure),
+            expected_tokens: vec![
+                lexer::Token::ReservedToken(lexer::ReservedToken::Choice),
+                lexer::Token::ReservedToken(lexer::ReservedToken::RightPrecedence),
+                lexer::Token::Char('.'),
+            ],
+        },
+    ));
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap_err();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
 fn test_closure_character() {
     let input_expression = "a*";
+    let input_alphabet = "ab";
+    let expected_output = dfa::Dfa {
+        n_states: 1,
+        start_state: 0,
+        accepting_states: HashSet::from([0]),
+        transition_function: HashMap::from([(0, HashMap::from([('a', 0)]))]),
+    };
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_closure_closure_character() {
+    let input_expression = "(a*)*";
     let input_alphabet = "ab";
     let expected_output = dfa::Dfa {
         n_states: 1,

--- a/src/tests/dfa_generation_tests.rs
+++ b/src/tests/dfa_generation_tests.rs
@@ -1,0 +1,338 @@
+use std::collections::{HashMap, HashSet};
+
+use super::*;
+
+#[test]
+fn test_empty_string() {
+    let input_expression = "";
+    let input_alphabet = "ab";
+    let expected_output = dfa::Dfa {
+        n_states: 1,
+        start_state: 0,
+        accepting_states: HashSet::from([0]),
+        transition_function: HashMap::new(),
+    };
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_character() {
+    let input_expression = "a";
+    let input_alphabet = "ab";
+    let expected_output = dfa::Dfa {
+        n_states: 2,
+        start_state: 0,
+        accepting_states: HashSet::from([1]),
+        transition_function: HashMap::from([(0, HashMap::from([('a', 1)]))]),
+    };
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_invalid_character() {
+    let input_expression = "z";
+    let input_alphabet = "ab";
+    let expected_output = DfaGenerationError::Lexical(lexer::LexicalError::CharacterParsing(
+        lexer::CharacterParsingError {
+            unmatchable_char: 'z',
+        },
+    ));
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap_err();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_closure_empty_string() {
+    let input_expression = "()*";
+    let input_alphabet = "";
+    let expected_output = dfa::Dfa {
+        n_states: 1,
+        start_state: 0,
+        accepting_states: HashSet::from([0]),
+        transition_function: HashMap::new(),
+    };
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_invalid_closure_empty_string() {
+    let input_expression = "*";
+    let input_alphabet = "";
+    let expected_output = DfaGenerationError::Syntactic(parser::SyntacticError::UnexpectedToken(
+        parser::UnexpectedTokenError {
+            token: lexer::Token::ReservedToken(lexer::ReservedToken::Closure),
+            expected_tokens: vec![
+                lexer::Token::Char('.'),
+                lexer::Token::ReservedToken(lexer::ReservedToken::LeftPrecedence),
+            ],
+        },
+    ));
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap_err();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_closure_character() {
+    let input_expression = "a*";
+    let input_alphabet = "ab";
+    let expected_output = dfa::Dfa {
+        n_states: 1,
+        start_state: 0,
+        accepting_states: HashSet::from([0]),
+        transition_function: HashMap::from([(0, HashMap::from([('a', 0)]))]),
+    };
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_concatenated_closure_character() {
+    let input_expression = "a*b*";
+    let input_alphabet = "ab";
+    let expected_output = dfa::Dfa {
+        n_states: 2,
+        start_state: 0,
+        accepting_states: HashSet::from([0, 1]),
+        transition_function: HashMap::from([
+            (0, HashMap::from([('a', 0), ('b', 1)])),
+            (1, HashMap::from([('b', 1)])),
+        ]),
+    };
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_concatenated_character_and_closure_character() {
+    let input_expression = "ab*";
+    let input_alphabet = "ab";
+    let expected_output = dfa::Dfa {
+        n_states: 2,
+        start_state: 0,
+        accepting_states: HashSet::from([1]),
+        transition_function: HashMap::from([
+            (0, HashMap::from([('a', 1)])),
+            (1, HashMap::from([('b', 1)])),
+        ]),
+    };
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_concatenated_closure_character_and_character() {
+    let input_expression = "a*b";
+    let input_alphabet = "ab";
+    let expected_output = dfa::Dfa {
+        n_states: 2,
+        start_state: 0,
+        accepting_states: HashSet::from([1]),
+        transition_function: HashMap::from([(0, HashMap::from([('a', 0), ('b', 1)]))]),
+    };
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_closure_concatenation() {
+    let input_expression = "(ab)*";
+    let input_alphabet = "ab";
+    let expected_output = dfa::Dfa {
+        n_states: 2,
+        start_state: 0,
+        accepting_states: HashSet::from([0]),
+        transition_function: HashMap::from([
+            (0, HashMap::from([('a', 1)])),
+            (1, HashMap::from([('b', 0)])),
+        ]),
+    };
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_choice_character_character() {
+    let input_expression = "a|b";
+    let input_alphabet = "ab";
+    let expected_output = dfa::Dfa {
+        n_states: 2,
+        start_state: 0,
+        accepting_states: HashSet::from([1]),
+        transition_function: HashMap::from([(0, HashMap::from([('a', 1), ('b', 1)]))]),
+    };
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_choice_character_empty_string() {
+    let input_expression = "|a";
+    let input_alphabet = "ab";
+    let expected_output = dfa::Dfa {
+        n_states: 2,
+        start_state: 0,
+        accepting_states: HashSet::from([0, 1]),
+        transition_function: HashMap::from([(0, HashMap::from([('a', 1)]))]),
+    };
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_invalid_choice_character_empty_string() {
+    let input_expression = "a|";
+    let input_alphabet = "ab";
+    let expected_output = DfaGenerationError::Syntactic(
+        parser::SyntacticError::MissingExpectedToken(parser::MissingExpectedTokenError {
+            expected_tokens: vec![
+                lexer::Token::Char('.'),
+                lexer::Token::ReservedToken(lexer::ReservedToken::LeftPrecedence),
+            ],
+        }),
+    );
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap_err();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_choice_empty_string_empty_string() {
+    let input_expression = "()|()";
+    let input_alphabet = "ab";
+    let expected_output = dfa::Dfa {
+        n_states: 1,
+        start_state: 0,
+        accepting_states: HashSet::from([0]),
+        transition_function: HashMap::new(),
+    };
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_invalid_choice_empty_string_empty_string() {
+    let input_expression = "|";
+    let input_alphabet = "ab";
+    let expected_output = DfaGenerationError::Syntactic(
+        parser::SyntacticError::MissingExpectedToken(parser::MissingExpectedTokenError {
+            expected_tokens: vec![
+                lexer::Token::Char('.'),
+                lexer::Token::ReservedToken(lexer::ReservedToken::LeftPrecedence),
+            ],
+        }),
+    );
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap_err();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_choice_character_concatenation() {
+    let input_expression = "a|ab";
+    let input_alphabet = "ab";
+    let expected_output = dfa::Dfa {
+        n_states: 3,
+        start_state: 0,
+        accepting_states: HashSet::from([1, 2]),
+        transition_function: HashMap::from([
+            (0, HashMap::from([('a', 1)])),
+            (1, HashMap::from([('b', 2)])),
+        ]),
+    };
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_choice_concatenation_concatenation() {
+    // This test needs to check two possible outputs, because DFA generated depends on
+    // a random access to a HashMap and thus could follow either of the "ab" or "ba"
+    // branch first.
+    let input_expression = "ab|ba";
+    let input_alphabet = "ab";
+    let expected_output_a = dfa::Dfa {
+        n_states: 4,
+        start_state: 0,
+        accepting_states: HashSet::from([3]),
+        transition_function: HashMap::from([
+            (0, HashMap::from([('a', 1), ('b', 2)])),
+            (1, HashMap::from([('b', 3)])),
+            (2, HashMap::from([('a', 3)])),
+        ]),
+    };
+    let expected_output_b = dfa::Dfa {
+        n_states: 4,
+        start_state: 0,
+        accepting_states: HashSet::from([3]),
+        transition_function: HashMap::from([
+            (0, HashMap::from([('b', 1), ('a', 2)])),
+            (1, HashMap::from([('a', 3)])),
+            (2, HashMap::from([('b', 3)])),
+        ]),
+    };
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    assert!(output == expected_output_a || output == expected_output_b);
+}
+
+#[test]
+fn test_concatenated_choice_character() {
+    let input_expression = "(a|b)a";
+    let input_alphabet = "ab";
+    let expected_output = dfa::Dfa {
+        n_states: 3,
+        start_state: 0,
+        accepting_states: HashSet::from([2]),
+        transition_function: HashMap::from([
+            (0, HashMap::from([('a', 1), ('b', 1)])),
+            (1, HashMap::from([('a', 2)])),
+        ]),
+    };
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_concatenated_character_choice() {
+    let input_expression = "a(a|b)";
+    let input_alphabet = "ab";
+    let expected_output = dfa::Dfa {
+        n_states: 3,
+        start_state: 0,
+        accepting_states: HashSet::from([2]),
+        transition_function: HashMap::from([
+            (0, HashMap::from([('a', 1)])),
+            (1, HashMap::from([('a', 2), ('b', 2)])),
+        ]),
+    };
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_redundant_parentheses() {
+    let input_expression = "((a))";
+    let input_alphabet = "ab";
+    let expected_output = dfa::Dfa {
+        n_states: 2,
+        start_state: 0,
+        accepting_states: HashSet::from([1]),
+        transition_function: HashMap::from([(0, HashMap::from([('a', 1)]))]),
+    };
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_empty_string_concatenation() {
+    let input_expression = "a()";
+    let input_alphabet = "ab";
+    let expected_output = dfa::Dfa {
+        n_states: 2,
+        start_state: 0,
+        accepting_states: HashSet::from([1]),
+        transition_function: HashMap::from([(0, HashMap::from([('a', 1)]))]),
+    };
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    assert_eq!(output, expected_output);
+}

--- a/src/tests/dfa_generation_tests.rs
+++ b/src/tests/dfa_generation_tests.rs
@@ -12,7 +12,7 @@ fn test_empty_string() {
         accepting_states: HashSet::from([0]),
         transition_function: HashMap::new(),
     };
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
 }
 
@@ -26,7 +26,7 @@ fn test_character() {
         accepting_states: HashSet::from([1]),
         transition_function: HashMap::from([(0, HashMap::from([('a', 1)]))]),
     };
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
 }
 
@@ -39,7 +39,7 @@ fn test_invalid_character() {
             unmatchable_char: 'z',
         },
     ));
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap_err();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap_err();
     assert_eq!(output, expected_output);
 }
 
@@ -53,7 +53,7 @@ fn test_closure_empty_string() {
         accepting_states: HashSet::from([0]),
         transition_function: HashMap::new(),
     };
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
 }
 
@@ -70,7 +70,7 @@ fn test_invalid_closure_empty_string() {
             ],
         },
     ));
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap_err();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap_err();
     assert_eq!(output, expected_output);
 }
 
@@ -84,7 +84,7 @@ fn test_closure_closure_empty_string() {
         accepting_states: HashSet::from([0]),
         transition_function: HashMap::new(),
     };
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
 }
 
@@ -102,7 +102,7 @@ fn test_invalid_closure_closure_empty_string() {
             ],
         },
     ));
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap_err();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap_err();
     assert_eq!(output, expected_output);
 }
 
@@ -116,7 +116,7 @@ fn test_closure_character() {
         accepting_states: HashSet::from([0]),
         transition_function: HashMap::from([(0, HashMap::from([('a', 0)]))]),
     };
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
 }
 
@@ -130,7 +130,7 @@ fn test_closure_closure_character() {
         accepting_states: HashSet::from([0]),
         transition_function: HashMap::from([(0, HashMap::from([('a', 0)]))]),
     };
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
 }
 
@@ -147,7 +147,7 @@ fn test_concatenated_closure_character() {
             (1, HashMap::from([('b', 1)])),
         ]),
     };
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
 }
 
@@ -164,7 +164,7 @@ fn test_concatenated_character_and_closure_character() {
             (1, HashMap::from([('b', 1)])),
         ]),
     };
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
 }
 
@@ -178,7 +178,7 @@ fn test_concatenated_closure_character_and_character() {
         accepting_states: HashSet::from([1]),
         transition_function: HashMap::from([(0, HashMap::from([('a', 0), ('b', 1)]))]),
     };
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
 }
 
@@ -195,7 +195,7 @@ fn test_closure_concatenation() {
             (1, HashMap::from([('b', 0)])),
         ]),
     };
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
 }
 
@@ -209,7 +209,7 @@ fn test_choice_character_character() {
         accepting_states: HashSet::from([1]),
         transition_function: HashMap::from([(0, HashMap::from([('a', 1), ('b', 1)]))]),
     };
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
 }
 
@@ -223,7 +223,7 @@ fn test_choice_character_empty_string() {
         accepting_states: HashSet::from([0, 1]),
         transition_function: HashMap::from([(0, HashMap::from([('a', 1)]))]),
     };
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
 }
 
@@ -239,7 +239,7 @@ fn test_invalid_choice_character_empty_string() {
             ],
         }),
     );
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap_err();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap_err();
     assert_eq!(output, expected_output);
 }
 
@@ -253,7 +253,7 @@ fn test_choice_empty_string_empty_string() {
         accepting_states: HashSet::from([0]),
         transition_function: HashMap::new(),
     };
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
 }
 
@@ -269,7 +269,7 @@ fn test_invalid_choice_empty_string_empty_string() {
             ],
         }),
     );
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap_err();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap_err();
     assert_eq!(output, expected_output);
 }
 
@@ -286,7 +286,7 @@ fn test_choice_character_concatenation() {
             (1, HashMap::from([('b', 2)])),
         ]),
     };
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
 }
 
@@ -317,7 +317,7 @@ fn test_choice_concatenation_concatenation() {
             (2, HashMap::from([('b', 3)])),
         ]),
     };
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert!(output == expected_output_a || output == expected_output_b);
 }
 
@@ -334,7 +334,7 @@ fn test_concatenated_choice_character() {
             (1, HashMap::from([('a', 2)])),
         ]),
     };
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
 }
 
@@ -351,7 +351,7 @@ fn test_concatenated_character_choice() {
             (1, HashMap::from([('a', 2), ('b', 2)])),
         ]),
     };
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
 }
 
@@ -365,7 +365,7 @@ fn test_redundant_parentheses() {
         accepting_states: HashSet::from([1]),
         transition_function: HashMap::from([(0, HashMap::from([('a', 1)]))]),
     };
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
 }
 
@@ -379,7 +379,7 @@ fn test_concatenated_char_and_empty_string() {
         accepting_states: HashSet::from([1]),
         transition_function: HashMap::from([(0, HashMap::from([('a', 1)]))]),
     };
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
 }
 
@@ -393,6 +393,6 @@ fn test_concatenated_empty_string_and_char() {
         accepting_states: HashSet::from([1]),
         transition_function: HashMap::from([(0, HashMap::from([('a', 1)]))]),
     };
-    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
 }

--- a/src/tests/dfa_generation_tests.rs
+++ b/src/tests/dfa_generation_tests.rs
@@ -324,8 +324,22 @@ fn test_redundant_parentheses() {
 }
 
 #[test]
-fn test_empty_string_concatenation() {
+fn test_concatenated_char_and_empty_string() {
     let input_expression = "a()";
+    let input_alphabet = "ab";
+    let expected_output = dfa::Dfa {
+        n_states: 2,
+        start_state: 0,
+        accepting_states: HashSet::from([1]),
+        transition_function: HashMap::from([(0, HashMap::from([('a', 1)]))]),
+    };
+    let output = generate_dfa(&input_expression, &input_alphabet).unwrap();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
+fn test_concatenated_empty_string_and_char() {
+    let input_expression = "()a";
     let input_alphabet = "ab";
     let expected_output = dfa::Dfa {
         n_states: 2,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,0 +1,4 @@
+use super::*;
+
+#[cfg(test)]
+mod dfa_generation_tests;


### PR DESCRIPTION
## Overview

<!-- Provide a brief overview of the contents of this PR, including when applicable: 
    - Links to relevant resources e.g. documentation or related issues
    - Commentary on any changes made to the proposals made in any related issues
-->

This PR exposes a DFA generation function which takes an alphabet and regular expression string as input and produces a DFA as output. It also adds unit tests for this function.

- Issue #29 

## Validation

<!-- Describe how you validated this MR, including when applicable: 
    - Screenshots of the visual changes made
    - An ordered list of steps for local validation
    - An overview of the automated tests added to the codebase
-->

The unit tests validate the following cases (assume alphabet is valid unless otherwise specified):
- ""
- "a"
- "z" on alphabet "ab"
- "()*"
- "*"
- "(()*)*"
- "()**"
- "a*"
- "(a*)*"
- "a*b*"
- "ab*"
- "a*b"
- "(ab)*"
- "a|b"
- "|a"
- "a|"
- "|()"
- "|"
- "a|ab"
- "ab|ba"
- "(a|b)a"
- "a(a|b)"
- "((a))"
- "a()"
- "()a"

These are all the edge cases which I could come up with.
