### PR TITLE
32 dfa generation incorrectly handles nullables in concatenation

### DIFF
--- a/src/dfa/mod.rs
+++ b/src/dfa/mod.rs
@@ -33,12 +33,16 @@ fn calculate_matches_next(
             for sub_expression in sub_expressions {
                 calculate_matches_next(sub_expression, matches_next);
             }
-            for i in 0..sub_expressions.len() - 1 {
+            let mut global_matches_start = HashSet::new();
+            for i in (0..sub_expressions.len()).rev() {
                 let prev_expression = &sub_expressions[i];
-                let next_expression = &sub_expressions[i + 1];
                 for j in &prev_expression.matches_end {
-                    matches_next[*j].extend(next_expression.matches_start.iter().copied());
+                    matches_next[*j].extend(global_matches_start.iter());
                 }
+                if !prev_expression.is_nullable {
+                    global_matches_start = HashSet::new();
+                }
+                global_matches_start.extend(prev_expression.matches_start.iter().copied());
             }
         }
         AnnotatedExpressionType::Closure(sub_expression) => {

--- a/src/tests/dfa_generation_tests.rs
+++ b/src/tests/dfa_generation_tests.rs
@@ -200,6 +200,54 @@ fn test_closure_concatenation() {
 }
 
 #[test]
+fn test_multiple_concatenated_closures() {
+    // This test needs to check many possible outputs, because DFA generated depends on
+    // a random access to a HashMap and thus could follow one of many branches first.
+    let input_expression = "ab*c*d";
+    let input_alphabet = "abcd";
+    let expected_output_a = dfa::Dfa {
+        n_states: 4,
+        start_state: 0,
+        accepting_states: HashSet::from([3]),
+        transition_function: HashMap::from([
+            (0, HashMap::from([('a', 1)])),
+            (1, HashMap::from([('b', 1), ('c', 2), ('d', 3)])),
+            (2, HashMap::from([('c', 2), ('d', 3)])),
+        ]),
+    };
+    let expected_output_b = dfa::Dfa {
+        n_states: 4,
+        start_state: 0,
+        accepting_states: HashSet::from([2]),
+        transition_function: HashMap::from([
+            (0, HashMap::from([('a', 1)])),
+            (1, HashMap::from([('b', 1), ('d', 2), ('c', 3)])),
+            (3, HashMap::from([('c', 3), ('d', 2)])),
+        ]),
+    };
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
+    assert!(output == expected_output_a || output == expected_output_b);
+}
+
+#[test]
+fn test_concatenated_choice_closure() {
+    let input_expression = "a(a|b)*b";
+    let input_alphabet = "ab";
+    let expected_output = dfa::Dfa {
+        n_states: 3,
+        start_state: 0,
+        accepting_states: HashSet::from([2]),
+        transition_function: HashMap::from([
+            (0, HashMap::from([('a', 1)])),
+            (1, HashMap::from([('a', 1), ('b', 2)])),
+            (2, HashMap::from([('a', 1), ('b', 2)])),
+        ]),
+    };
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
+    assert_eq!(output, expected_output);
+}
+
+#[test]
 fn test_choice_character_character() {
     let input_expression = "a|b";
     let input_alphabet = "ab";
@@ -395,34 +443,4 @@ fn test_concatenated_empty_string_and_char() {
     };
     let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
-}
-
-#[test]
-fn test_nullable_concatenation() {
-    // This test needs to check many possible outputs, because DFA generated depends on
-    // a random access to a HashMap and thus could follow one of many branches first.
-    let input_expression = "ab*c*d";
-    let input_alphabet = "abcd";
-    let expected_output_a = dfa::Dfa {
-        n_states: 4,
-        start_state: 0,
-        accepting_states: HashSet::from([3]),
-        transition_function: HashMap::from([
-            (0, HashMap::from([('a', 1)])),
-            (1, HashMap::from([('b', 1), ('c', 2), ('d', 3)])),
-            (2, HashMap::from([('c', 2), ('d', 3)])),
-        ]),
-    };
-    let expected_output_b = dfa::Dfa {
-        n_states: 4,
-        start_state: 0,
-        accepting_states: HashSet::from([2]),
-        transition_function: HashMap::from([
-            (0, HashMap::from([('a', 1)])),
-            (1, HashMap::from([('b', 1), ('d', 2), ('c', 3)])),
-            (3, HashMap::from([('c', 3), ('d', 2)])),
-        ]),
-    };
-    let output = generate_dfa(input_expression, input_alphabet).unwrap();
-    assert!(output == expected_output_a || output == expected_output_b);
 }

--- a/src/tests/dfa_generation_tests.rs
+++ b/src/tests/dfa_generation_tests.rs
@@ -396,3 +396,33 @@ fn test_concatenated_empty_string_and_char() {
     let output = generate_dfa(input_expression, input_alphabet).unwrap();
     assert_eq!(output, expected_output);
 }
+
+#[test]
+fn test_nullable_concatenation() {
+    // This test needs to check many possible outputs, because DFA generated depends on
+    // a random access to a HashMap and thus could follow one of many branches first.
+    let input_expression = "ab*c*d";
+    let input_alphabet = "abcd";
+    let expected_output_a = dfa::Dfa {
+        n_states: 4,
+        start_state: 0,
+        accepting_states: HashSet::from([3]),
+        transition_function: HashMap::from([
+            (0, HashMap::from([('a', 1)])),
+            (1, HashMap::from([('b', 1), ('c', 2), ('d', 3)])),
+            (2, HashMap::from([('c', 2), ('d', 3)])),
+        ]),
+    };
+    let expected_output_b = dfa::Dfa {
+        n_states: 4,
+        start_state: 0,
+        accepting_states: HashSet::from([2]),
+        transition_function: HashMap::from([
+            (0, HashMap::from([('a', 1)])),
+            (1, HashMap::from([('b', 1), ('d', 2), ('c', 3)])),
+            (3, HashMap::from([('c', 3), ('d', 2)])),
+        ]),
+    };
+    let output = generate_dfa(input_expression, input_alphabet).unwrap();
+    assert!(output == expected_output_a || output == expected_output_b);
+}


### PR DESCRIPTION
## Overview

<!-- Provide a brief overview of the contents of this PR, including when applicable: 
    - Links to relevant resources e.g. documentation or related issues
    - Commentary on any changes made to the proposals made in any related issues
-->

This PR fixes the bug discussed in #32. 

- Related issue #32 

## Validation

<!-- Describe how you validated this MR, including when applicable: 
    - Screenshots of the visual changes made
    - An ordered list of steps for local validation
    - An overview of the automated tests added to the codebase
-->

The new automated tests check the case that was found to fail as well as the case of closure on choice.
