### PR TITLE
34 touch up semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ RIGHT_PRECEDENCE    ::= ")"
 The semantics of the regular expressions admitted by this crate are represented below in denotational semantics, mapping regular expressions to the set of strings they accept.
 A statement of the form $\left[\\!\left[ E \right]\\!\right] = V$ denotes a mapping between the expression $E$ and the mathematical object $V$.
 
-Aside from the common set operations, let us define $A \times B = \left\\{ab\\ \vert a \in A \wedge b \in B\right\\}$ for sets of strings $A, B$ where juxtaposition in $ab$ represents string concatenation.
+Aside from the common set operations, let us define $A \times B = \left\\{ab\\ \vert a \in A \wedge b \in B\right\\}$ for sets of strings $A, B$ where juxtaposition in $ab$ represents string concatenation. Similarly, let $E^n, n \in \mathbb{N}$ denote repeated concatenation of $n$ copies of $E$, and let $E^0 = \left\\{\epsilon\right\\}$
 
 Let $\epsilon$ represent the empty string.
 
@@ -60,4 +60,4 @@ $$\left[\\!\left[ AB \right]\\!\right] = \left[\\!\left[ A \right]\\!\right] \ti
 
 $$\left[\\!\left[ A|B \right]\\!\right] = \left[\\!\left[ A \right]\\!\right] \cup \left[\\!\left[ B \right]\\!\right]$$
 
-$$\left[\\!\left[ A^* \right]\\!\right] = \bigcup_{n \in \mathbf{N}} \left[\\!\left[ A \right]\\!\right]^n \cup \left\\{\epsilon\right\\}$$
+$$\left[\\!\left[ A^* \right]\\!\right] = \bigcup_{n \in \mathbb{N}_0} \left[\\!\left[ A \right]\\!\right]^n$$


### PR DESCRIPTION
## Overview

<!-- Provide a brief overview of the contents of this PR, including when applicable: 
    - Links to relevant resources e.g. documentation or related issues
    - Commentary on any changes made to the proposals made in any related issues
-->

Aside from explicitly defining expression exponentiation, the explicit union with {epsilon} was removed due to the definition of exponentiation with 0.

- Related issue #34 

## Validation

<!-- Describe how you validated this MR, including when applicable: 
    - Screenshots of the visual changes made
    - An ordered list of steps for local validation
    - An overview of the automated tests added to the codebase
-->

Changes can be viewed with `cargo doc --open`

| Before | After |
| ------- | ----- |
| <img width="873" alt="Screenshot 2025-02-19 at 13 38 47" src="https://github.com/user-attachments/assets/f368f8ad-cb13-4607-9c31-325cd31d883d" /> | <img width="909" alt="Screenshot 2025-02-19 at 13 41 18" src="https://github.com/user-attachments/assets/5fd869ec-0b05-4c9e-972f-a7beace86166" /> |
